### PR TITLE
Enlarge image first if necessary

### DIFF
--- a/app/src/utils/blur-detector.ts
+++ b/app/src/utils/blur-detector.ts
@@ -21,6 +21,7 @@ class BlurryDetector {
     // Convolve the image with the Laplacian kernel
     const laplacianImageData = await sharp(jpegified)
       .greyscale()
+      .resize({ width: 1000, withoutReduction: true })
       .raw()
       .convolve(laplacianKernel)
       .toBuffer();


### PR DESCRIPTION
We had one test case image that was very tiny, and returning as being "sharp". It wouldn't be sharp if it were upsized, as the text would actually be completely illegible. Let's make sure these documents are at a minimum size first.