### PR TITLE
align header ACME Demo next to logo

### DIFF
--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -29,7 +29,7 @@ const Layout = ({ children, hideContact }: Props): ReactElement => (
 
     <Header className="usa-header usa-header--basic">
       <div className="usa-nav-container">
-        <div className="usa-navbar usa-logo height-8">
+        <div className="usa-navbar usa-logo height-8 display-flex flex-align-center">
           <img
             className="width-6"
             src="/logo.svg"


### PR DESCRIPTION
## No ticket, just fixes

## Changes
> Previously, when you'd start the page on a desktop width (not mobile), the ACME Demo title would be on a new line after the logo. Now, it will be on the same line.

<img width="331" alt="image" src="https://github.com/DSACMS/iv-doc-uploader/assets/776667/2a33ce93-b030-4bba-aba3-8685fa3870bf">

This is how it _should_ look.
