### PR TITLE
Improve UX of OCR-recognized images

### DIFF
--- a/app/next.config.js
+++ b/app/next.config.js
@@ -18,7 +18,7 @@ const nextConfig = {
   reactStrictMode: true,
   sassOptions: appSassOptions,
   productionBrowserSourceMaps: true,
-  serverComponentsExternalPackages: ['tesseract.js']
+  serverComponentsExternalPackages: ["tesseract.js"],
 };
 
 module.exports = nextConfig;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -59,7 +59,7 @@
         "postcss": "^8.4.21",
         "postcss-loader": "^7.1.0",
         "postcss-preset-env": "^8.0.1",
-        "prettier": "^2.8.4",
+        "prettier": "^2.8.8",
         "sass": "^1.59.3",
         "sass-loader": "^13.2.0",
         "storybook-react-i18next": "^1.1.3",

--- a/app/package.json
+++ b/app/package.json
@@ -69,7 +69,7 @@
     "postcss": "^8.4.21",
     "postcss-loader": "^7.1.0",
     "postcss-preset-env": "^8.0.1",
-    "prettier": "^2.8.4",
+    "prettier": "^2.8.8",
     "sass": "^1.59.3",
     "sass-loader": "^13.2.0",
     "storybook-react-i18next": "^1.1.3",

--- a/app/src/pages/api/upload.ts
+++ b/app/src/pages/api/upload.ts
@@ -116,8 +116,10 @@ const ocrDetectionAction = async (
   const fulfilled = fulfilledFiles.map((result) => {
     // don't send the image data to the client, but keep the filename
     result.value.data.map((doc) => {
-      const fileName = doc.image.fileName;
-      doc.fileName = fileName;
+      if (doc.image) {
+        const fileName = doc.image.fileName;
+        doc.fileName = fileName;
+      }
       delete doc.image;
       return doc;
     });

--- a/app/src/pages/api/upload.ts
+++ b/app/src/pages/api/upload.ts
@@ -114,8 +114,10 @@ const ocrDetectionAction = async (
   ) as unknown as PromiseRejectedResult[];
 
   const fulfilled = fulfilledFiles.map((result) => {
-    // don't send the image data to the client
+    // don't send the image data to the client, but keep the filename
     result.value.data.map((doc) => {
+      const fileName = doc.image.fileName;
+      doc.fileName = fileName;
       delete doc.image;
       return doc;
     });

--- a/app/src/pages/upload/confirmation.tsx
+++ b/app/src/pages/upload/confirmation.tsx
@@ -33,7 +33,6 @@ const createLegibileIncidatorText = (isBlurry: boolean) => {
   return isBlurry ? " may be too blurry to read." : " successfully uploaded.";
 };
 
-
 const createBlurrinessIncidatorIcon = (isBlurry: boolean) => {
   return (
     <>
@@ -60,22 +59,31 @@ const createBlurrinessIncidatorIcon = (isBlurry: boolean) => {
 const renderDocumentFields = (docFields: ParsingFunctionResult) => {
   // ignore the top-level keys, just show an alert if there is any
   // data in the second level
-  const recognizedData = Object.entries(docFields).map(([_docType, fields]) => {
-    return Object.entries(fields).filter(([_, v]) => v != "");
-  }).flat();
+  const recognizedData = Object.entries(docFields)
+    .map(([, fields]) => {
+      return Object.entries(fields).filter(([, v]) => v !== "");
+    })
+    .flat();
 
   if (recognizedData.length > 0) {
     return (
       <Alert
-	type="success"
-	heading="We recognized text in your document!"
-	headingLevel="h4"
+        type="success"
+        heading="We recognized text in your document!"
+        headingLevel="h4"
       >
-	<strong>For demo purposes:</strong>{' '}
-	<span>We were able to recognize the following fields, which we could send to the caseworker:</span>
-	<ul>
-	  {recognizedData.map(([field, value], i) => <li key={i}><strong>{field}</strong>: {value}</li>)}
-	</ul>
+        <strong>For demo purposes:</strong>{" "}
+        <span>
+          We were able to recognize the following fields, which we could send to
+          the caseworker:
+        </span>
+        <ul>
+          {recognizedData.map(([field, value], i) => (
+            <li key={i}>
+              <strong>{field}</strong>: {value}
+            </li>
+          ))}
+        </ul>
       </Alert>
     );
   }
@@ -91,22 +99,23 @@ const renderOcrResults = (results: OCRDectionResponse) => {
       (doc) => doc.confidence === highestConfidenceScore
     )[0];
     const docFields = highestConfidenceOrientation.documents;
-    const isIllegible = highestConfidenceOrientation.confidence < BLURRINESS_THRESHOLD;
+    const isIllegible =
+      highestConfidenceOrientation.confidence < BLURRINESS_THRESHOLD;
 
     return (
       <div key={`document-${index}`}>
-	<IconListItem key={index} className="usa-icon-list__item">
-	  <>
-	    {createBlurrinessIncidatorIcon(isIllegible)}
-	    <IconListContent>
-	      {" "}
-	      {formatImagePath(highestConfidenceOrientation.fileName)}
-	      {createLegibileIncidatorText(isIllegible)}
-	      {` (confidence: ${highestConfidenceScore})`}
-	    </IconListContent>
-	  </>
-	</IconListItem>
-	{renderDocumentFields(docFields)}
+        <IconListItem key={index} className="usa-icon-list__item">
+          <>
+            {createBlurrinessIncidatorIcon(isIllegible)}
+            <IconListContent>
+              {" "}
+              {formatImagePath(highestConfidenceOrientation.fileName)}
+              {createLegibileIncidatorText(isIllegible)}
+              {` (confidence: ${highestConfidenceScore})`}
+            </IconListContent>
+          </>
+        </IconListItem>
+        {renderDocumentFields(docFields)}
       </div>
     );
   });

--- a/app/src/pages/upload/confirmation.tsx
+++ b/app/src/pages/upload/confirmation.tsx
@@ -1,4 +1,6 @@
+import { ParsingFunctionResult } from "@/service/ocr/parser";
 import {
+  Alert,
   IconList,
   IconListContent,
   IconListItem,
@@ -17,6 +19,8 @@ type ParsedBlurDecetorResults = ResponseData & {
   results: BlurryDetectorResults;
 };
 
+const BLURRINESS_THRESHOLD = 45;
+
 const formatImagePath = (path: string) => {
   return (path.match("([^/]+$)") || [])[0];
 };
@@ -24,6 +28,11 @@ const formatImagePath = (path: string) => {
 const createBlurrinessIncidatorText = (isBlurry: boolean) => {
   return isBlurry ? " is blurry." : " successfully uploaded.";
 };
+
+const createLegibileIncidatorText = (isBlurry: boolean) => {
+  return isBlurry ? " may be too blurry to read." : " successfully uploaded.";
+};
+
 
 const createBlurrinessIncidatorIcon = (isBlurry: boolean) => {
   return (
@@ -48,6 +57,30 @@ const createBlurrinessIncidatorIcon = (isBlurry: boolean) => {
   );
 };
 
+const renderDocumentFields = (docFields: ParsingFunctionResult) => {
+  // ignore the top-level keys, just show an alert if there is any
+  // data in the second level
+  const recognizedData = Object.entries(docFields).map(([_docType, fields]) => {
+    return Object.entries(fields).filter(([_, v]) => v != "");
+  }).flat();
+
+  if (recognizedData.length > 0) {
+    return (
+      <Alert
+	type="success"
+	heading="We recognized text in your document!"
+	headingLevel="h4"
+      >
+	<strong>For demo purposes:</strong>{' '}
+	<span>We were able to recognize the following fields, which we could send to the caseworker:</span>
+	<ul>
+	  {recognizedData.map(([field, value], i) => <li key={i}><strong>{field}</strong>: {value}</li>)}
+	</ul>
+      </Alert>
+    );
+  }
+};
+
 const renderOcrResults = (results: OCRDectionResponse) => {
   const elements = results.fulfilled.map((documentResults, index) => {
     // get the orientation with the highest confidence
@@ -58,18 +91,22 @@ const renderOcrResults = (results: OCRDectionResponse) => {
       (doc) => doc.confidence === highestConfidenceScore
     )[0];
     const docFields = highestConfidenceOrientation.documents;
+    const isIllegible = highestConfidenceOrientation.confidence < BLURRINESS_THRESHOLD;
 
     return (
       <div key={`document-${index}`}>
-        <h3>Document {index + 1}</h3>
-        <p>
-          <strong>Confidence:</strong> {highestConfidenceOrientation.confidence}
-        </p>
-        <p>
-          <strong>Rotation:</strong>{" "}
-          {highestConfidenceOrientation.rotatedOrientation}
-        </p>
-        {JSON.stringify(docFields, null, 2)}
+	<IconListItem key={index} className="usa-icon-list__item">
+	  <>
+	    {createBlurrinessIncidatorIcon(isIllegible)}
+	    <IconListContent>
+	      {" "}
+	      {formatImagePath(highestConfidenceOrientation.fileName)}
+	      {createLegibileIncidatorText(isIllegible)}
+	      {` (confidence: ${highestConfidenceScore})`}
+	    </IconListContent>
+	  </>
+	</IconListItem>
+	{renderDocumentFields(docFields)}
       </div>
     );
   });

--- a/app/src/service/factories.ts
+++ b/app/src/service/factories.ts
@@ -2,8 +2,8 @@ import { DocumentMatcher } from "@/service/ocr";
 import { DocumentImage, type DocumentOrientation } from "@/utils/document";
 import path from "path";
 import pino, { DestinationStream, LoggerOptions } from "pino";
+import "pino-pretty";
 import sharp from "sharp";
-import 'pino-pretty';
 
 export const createLogger = (
   name: string,

--- a/app/src/service/ocr/index.ts
+++ b/app/src/service/ocr/index.ts
@@ -99,6 +99,7 @@ const process = async (
 
   const result = {
     image: document,
+    fileName: document.fileName,
     documents: docs,
     percentages,
     confidence,

--- a/app/src/service/ocr/index.ts
+++ b/app/src/service/ocr/index.ts
@@ -25,6 +25,7 @@ export type OcrOptions = {
 export type ProcessedImageResult = {
   documents: ReturnType<typeof parse>;
   image?: DocumentImage;
+  fileName: string;
   percentages: Record<ParserKeys, number>;
   confidence: number;
   rotatedOrientation?: DocumentOrientation;


### PR DESCRIPTION
## Changes
Rather than dumping the JSON, let's output a USWDS style infobox with
the contents rendered a bit nicer for non-techies.

This also institutes an arbitrary "45" threshold of confidence to
consider the OCR result "legible". Although people on the internet say
that confidence really should be 95+, this is a lower bound that will
hopefully not raise too many false positives.

## Testing
Screenshots below:
<img width="664" alt="image" src="https://github.com/DSACMS/iv-doc-uploader/assets/129120/b34a079a-2b3a-4657-8745-4ca52afe2875">

<img width="678" alt="image" src="https://github.com/DSACMS/iv-doc-uploader/assets/129120/510b34b0-d064-48f8-aa4a-f2652ea4b988">

